### PR TITLE
Potential fix for code scanning alert no. 17: LDAP query built from user-controlled sources

### DIFF
--- a/powerdnsadmin/models/user.py
+++ b/powerdnsadmin/models/user.py
@@ -232,8 +232,10 @@ class User(db.Model):
                         .format(self.username, src_ip))
                     return False
 
+            # Escape user-controlled username before using it in LDAP filter
+            escaped_username = ldap.filter.escape_filter_chars(self.username or '')
             searchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_USERNAME,
-                                                    self.username,
+                                                    escaped_username,
                                                     LDAP_FILTER_BASIC)
             current_app.logger.debug('Ldap searchFilter {0}'.format(searchFilter))
 


### PR DESCRIPTION
Potential fix for [https://github.com/alsyundawy/PowerDNS-Admin/security/code-scanning/17](https://github.com/alsyundawy/PowerDNS-Admin/security/code-scanning/17)

In general, any user-controlled value inserted into an LDAP filter must be safely escaped using a robust, well-tested escaping function, rather than manual string manipulation. For Python using `ldap` (python-ldap), the recommended approach is to use `ldap.filter.escape_filter_chars` for filter components and `ldap.dn.escape_dn_chars` for DN components. Custom implementations should be avoided if possible.

The best minimal fix here is to ensure `self.username` is escaped before it is interpolated into the `searchFilter` string in `User.is_validate` when constructing the LDAP filter. Since `ldap.filter` is already imported at the top of `powerdnsadmin/models/user.py`, we can call `ldap.filter.escape_filter_chars(self.username)` and use that escaped value instead of `self.username` directly. This keeps existing behavior intact except for correctly escaping special characters. We do not need to modify `ldap_search` itself; sanitizing at the point where the filter string is built is sufficient and clearer. Optionally, we can later remove or deprecate the custom `escape_filter_chars` method in the `User` class, but to minimize changes we can leave it untouched for now.

Concretely:
- In `powerdnsadmin/models/user.py`, inside `User.is_validate`, just before `searchFilter` is constructed, compute `escaped_username = ldap.filter.escape_filter_chars(self.username or '')`.
- Use `escaped_username` in the filter format string: `searchFilter = "(&({0}={1}){2})".format(LDAP_FILTER_USERNAME, escaped_username, LDAP_FILTER_BASIC)`.
- No additional imports are necessary since `import ldap.filter` already exists at line 7.
- No changes are required in `decorators.py` or `routes/index.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
