### PR TITLE
Potential fix for code scanning alert no. 15: Reflected server-side cross-site scripting

### DIFF
--- a/powerdnsadmin/routes/api.py
+++ b/powerdnsadmin/routes/api.py
@@ -1201,23 +1201,31 @@ def api_get_zones(server_id):
             current_app.logger.debug("Account zones: {}".format('/'.join(accounts_domains)))
             content = json.dumps([i for i in json.loads(resp.content)
                                   if i['name'].rstrip('.') in allowed_domains])
-            return content, resp.status_code, resp.headers.items()
+            response = make_response(content, resp.status_code)
+            response.headers['Content-Type'] = 'application/json'
+            return response
         else:
-            return resp.content, resp.status_code, resp.headers.items()
+            response = make_response(resp.content, resp.status_code)
+            response.headers['Content-Type'] = 'application/json'
+            return response
 
 
 @api_bp.route('/servers', methods=['GET'])
 @apikey_auth
 def api_server_forward():
     resp = helper.forward_request()
-    return resp.content, resp.status_code, resp.headers.items()
+    response = make_response(resp.content, resp.status_code)
+    response.headers['Content-Type'] = 'application/json'
+    return response
 
 
 @api_bp.route('/servers/<string:server_id>', methods=['GET'])
 @apikey_auth
 def api_server_config_forward(server_id):
     resp = helper.forward_request()
-    return resp.content, resp.status_code, resp.headers.items()
+    response = make_response(resp.content, resp.status_code)
+    response.headers['Content-Type'] = 'application/json'
+    return response
 
 
 # The endpoint to synchronize Domains in background


### PR DESCRIPTION
Potential fix for [https://github.com/alsyundawy/PowerDNS-Admin/security/code-scanning/15](https://github.com/alsyundawy/PowerDNS-Admin/security/code-scanning/15)

In general, to fix this problem we must ensure that any content derived from user input cannot cause script execution in the browser. For API proxy endpoints, the safest approach is to (a) constrain what we send back (e.g., only JSON), and/or (b) ensure the correct content type and avoid blindly forwarding upstream headers that could relax browser protections. We should not modify the functional data returned (i.e., the JSON body) but we can wrap or normalize the response using Flask’s response utilities instead of returning the raw `requests` response parts.

The best minimal fix here is to convert the proxied responses into proper Flask `Response` objects with a controlled `Content-Type`, rather than forwarding `resp.content` and `resp.headers.items()` directly. For JSON-based PDNS APIs this means: decode the upstream JSON (or treat bytes as-is), and then use `make_response`/`jsonify` while explicitly setting `Content-Type: application/json` and selectively propagating only safe headers (e.g., not `Content-Type`/`Content-Length` from upstream). This keeps the actual JSON payload intact (no escaping necessary, since JSON strings cannot contain executable script by themselves when parsed as JSON) while preventing the application from ever serving attacker-controlled HTML/JS with a browser-executable content type through these proxy endpoints.

Concretely, in `powerdnsadmin/routes/api.py` we should change:
- In `api_get_zones`, the `else` branch’s final `return resp.content, resp.status_code, resp.headers.items()`.
- In `api_server_forward`, the `return resp.content, resp.status_code, resp.headers.items()`.
- In `api_server_config_forward`, the `return resp.content, resp.status_code, resp.headers.items()`.

We will replace these with calls to `make_response(resp.content, resp.status_code)` and then force the `Content-Type` header to `application/json` (or the specific expected type) while not forwarding arbitrary upstream headers. `make_response` is already imported at the top of the file, so no new imports are needed. This preserves HTTP status codes and bodies while limiting the possibility that the browser will execute content as HTML/JS.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
