### PR TITLE
Potential fix for code scanning alert no. 16: Flask app is run in debug mode

### DIFF
--- a/run.py
+++ b/run.py
@@ -3,4 +3,5 @@ from powerdnsadmin import create_app
 
 if __name__ == '__main__':
     app = create_app()
-    app.run(debug=True, host=app.config.get('BIND_ADDRESS', '127.0.0.1'), port=app.config.get('PORT', '9191'))
+    debug = app.config.get('DEBUG', False)
+    app.run(debug=debug, host=app.config.get('BIND_ADDRESS', '127.0.0.1'), port=app.config.get('PORT', '9191'))


### PR DESCRIPTION
Potential fix for [https://github.com/alsyundawy/PowerDNS-Admin/security/code-scanning/16](https://github.com/alsyundawy/PowerDNS-Admin/security/code-scanning/16)

To fix the problem in general, ensure that `app.run` is not invoked with `debug=True` unconditionally. Instead, either omit the `debug` parameter (letting configuration decide), or compute it from a trusted configuration source or environment variable so production runs have debugging disabled.

The best targeted fix here, without altering existing behavior more than necessary, is to stop hardcoding `debug=True` and instead read a `DEBUG` (or equivalent) setting from `app.config`. That allows developers to enable debug mode via configuration for local use, while production configs can set it to `False`. Concretely, in `run.py` line 6, introduce a local `debug` variable derived from `app.config.get('DEBUG', False)` and pass that into `app.run`, or simply drop the `debug` argument and rely on Flask’s `app.debug` / `DEBUG` config if it’s already used. Since we must only touch the shown snippet, we will add the `debug` variable right before the `app.run` call and replace `debug=True` with `debug=debug`. This preserves the ability to run in debug when `DEBUG` is set in the config, while ensuring that, by default, the app does not run with debug enabled.

Specifically, in `run.py` within the `if __name__ == '__main__':` block, we will change:

- Line 5: keep `app = create_app()` as is.
- Insert a new line 6 defining `debug = app.config.get('DEBUG', False)`.
- Replace the existing line 6 `app.run(debug=True, host=..., port=...)` with a call using `debug=debug`.

No new imports or external dependencies are needed; we only use `app.config.get`, which is already in use for `BIND_ADDRESS` and `PORT`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
